### PR TITLE
Adding auto-updating

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Heretic",
     "game_name": "heretic",
-    "package_version": "0.0.1.3",
+    "package_version": "0.0.1.4",
     "package_uid": "ap_heretic",
     "author": "Forsaken",
     "variants": {
@@ -10,5 +10,5 @@
             "flags": ["ap"]
         }
     },
-    "versions_url": ""
+    "versions_url": "https://github.com/Forsaken-angel/heretic-ap-tracker/main/versions.json"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Heretic",
     "game_name": "heretic",
-    "package_version": "0.0.1.0",
+    "package_version": "0.0.1.3",
     "package_uid": "ap_heretic",
     "author": "Forsaken",
     "variants": {

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,12 @@
+{
+  "versions": [
+    {
+      "package_version": "0.0.1.3",
+      "download_url": "https://github.com/Forsaken-angel/heretic-ap-tracker/archive/refs/tags/v0.0.1.3.zip",
+      "sha256": "083dc01f6ad860e971a82f5d296a34df3299a351fa35cfd312a78d03250427e5",
+      "changelog": [
+        "Pro Mode has been properly implemented and can now be used to check for jumps on a few stages!"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Update the package_version in manifest.json to the next release number (since there have been changes made since the last release).
Add versions.json and set the versions_url in manifest.json to point to it to be used for auto-updating.  (Once this commit is released, a new version will be added to versions.json; this must come after release in order to get the hash of the zip.)