### PR TITLE
Add hash of latest package

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,6 +3,14 @@
     {
       "package_version": "0.0.1.4",
       "download_url": "https://github.com/Forsaken-angel/heretic-ap-tracker/archive/refs/tags/v0.0.1.4.zip",
+      "sha256": "f7404408820118dcf80992838220cd1762ae62eb9af20b745c9b56e734a3d469",
+      "changelog": [
+        "Logic Fixes"
+      ]
+    },
+    {
+      "package_version": "0.0.1.3",
+      "download_url": "https://github.com/Forsaken-angel/heretic-ap-tracker/archive/refs/tags/v0.0.1.3.zip",
       "sha256": "083dc01f6ad860e971a82f5d296a34df3299a351fa35cfd312a78d03250427e5",
       "changelog": [
         "Pro Mode has been properly implemented and can now be used to check for jumps on a few stages!"


### PR DESCRIPTION
When updating the package version, a new version object needs to be added with the sha256 value for the new release's zip file.  One place the sha256 can be obtained is by uploading the zip file here: https://emn178.github.io/online-tools/sha256_checksum.html